### PR TITLE
Fixed verbose display issue

### DIFF
--- a/FdSig.py
+++ b/FdSig.py
@@ -245,3 +245,4 @@ if __name__ == "__main__" or True:
             imshowEx(fa, title = "freq")
             pyplot.subplot(224)
             imshowEx(xb, title = "deco")
+            pyplot.show() #display


### PR DESCRIPTION
pyplot does not show the "verbose" graph without being explicitly told to do so.